### PR TITLE
Fixed bundleanalyzer addon setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "license": "MIT",
   "scripts": {
     "dev": "webpack-dev-server --env.env=dev",
-    "dev:bundleanalyzer": "yarn dev --env.addons=bundleanalyzer",
+    "dev:bundleanalyzer": "yarn dev -- --env.addons=bundleanalyzer",
     "prebuild": "rimraf dist",
     "build": "cross-env NODE_ENV=production webpack -p --env.env=prod",
-    "build:bundleanalyzer": "yarn build --env.addons=bundleanalyzer"
+    "build:bundleanalyzer": "yarn build -- --env.addons=bundleanalyzer"
   },
   "dependencies": {
     "react": "^16.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,9 +7,7 @@ const addons = (/* string | string[] */ addonsArg) => {
   let addons = [...[addonsArg]] // Normalize array of addons (flatten)
     .filter(Boolean); // If addons is undefined, filter it out
 
-  return addons.map(addonName =>
-    require(`./build-utils/addons/webpack.${addonName}.js`)
-  );
+  return addons.map(addonName => require(`./build-utils/addons/webpack.${addonName}.js`));
 };
 
 module.exports = env => {


### PR DESCRIPTION
Added missing "--" to fix "--env.addons=bundleanalyzer" not being passed to the other yarn scripts.